### PR TITLE
Only set fifo-arguments if fifo queue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 resource "aws_sqs_queue" "this" {
   name                        = var.is_fifo ? "${var.name}.fifo" : var.name
   fifo_queue                  = var.is_fifo
-  deduplication_scope         = var.deduplication_scope
-  fifo_throughput_limit       = var.fifo_throughput_limit
+  deduplication_scope         = var.is_fifo ? var.deduplication_scope : null
+  fifo_throughput_limit       = var.is_fifo ? var.fifo_throughput_limit : null
   content_based_deduplication = var.content_based_deduplication
   visibility_timeout_seconds  = var.visibility_timeout
   sqs_managed_sse_enabled     = true


### PR DESCRIPTION
Forhindrer feil som `operation error SQS: SetQueueAttributes, https response error StatusCode: 400, RequestID: 690bdad6-bf0d-5b1a-9832-ba5ab58c26dc, InvalidAttributeName: You can specify the DeduplicationScope only when FifoQueue is set to true.` fra default-argumenter som går på fifo-køer